### PR TITLE
Add validation for groups and fix character tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,17 @@ $ python3 hubbard_diag_v5.py 2 "c2"
 The file groups.py contain some of the more common groups such that only typing the name as a string of the group under Schonflies convention is enough. 
 
 ## The group I want is not in groups.py ?
-You need to add it. Here is how:
+If you request a combination of sites and group that is not supported,
+``group_create`` will now raise a ``ValueError``.  To add support for a new
+group you need to extend ``groups.py``.  Here is how:
 
-You need to know how your group permute your sites. 
+You need to know how your group permutes your sites.
 
-For example, the group c2 for 3 sites is symmetric under reflection of site 0 and site 1 along the axis of site 2. 
-Hence, the initial configuration [0,1,2] after c2 reflexion is now [1,0,2]. The latter list is the symmetry generator that you have to add to the function group_create in groups.py as sym_gen. 
+For example, the group c2 for 3 sites is symmetric under reflection of site 0
+and site 1 along the axis of site 2. Hence, the initial configuration [0,1,2]
+after c2 reflexion is now [1,0,2]. The latter list is the symmetry generator
+that you have to add to the function ``group_create`` in ``groups.py`` as
+``sym_gen``.
 
 Here, sym_gen is a list of lists because we can combine multiple symmetry generators to make more complicate groups. For exemple, we can create the non-abelian group d3 by combining the c2 symmetry generator [1,0,2] with c3 symmetry generator [2,0,1]:
 ```
@@ -50,7 +55,10 @@ def group_create(Nsites,group):
                          [2,0,-1,0,-1,0]]
 
 ```
-As you see, you also need to give the character table of the group. Ultimately, it would be cool if the program could generate the character table only from the symmetry generator, but for now we have to write it ourself. Also, it is important that the characters fit the group element order. 
+As you see, you also need to give the character table of the group.  In the
+future we hope to generate these tables automatically from the generators, but
+for now they must be specified explicitly.  Also, it is important that the
+characters fit the group element order.
 
 ## Example of use
 So I want to know the eigenvalues of the 3 sites Hubbard Hamiltonian... 

--- a/groups.py
+++ b/groups.py
@@ -1,35 +1,59 @@
+"""Utility functions related to symmetry groups.
+
+Currently, only a very small set of groups and site counts are supported.
+The :func:`group_create` helper returns both the symmetry generators and the
+character table associated with the requested configuration.
+
+New groups can be added by extending the conditional table below.  Each new
+entry must specify the permutation generators (``sym_gen``) and the
+corresponding character table (``char_table``).  In the future, it may be
+possible to automatically generate character tables directly from the
+generators.
+"""
 
 
+def group_create(Nsites, group):
+    """Return symmetry generators and character table for a given group.
 
+    Parameters
+    ----------
+    Nsites : int
+        Number of lattice sites.
+    group : str
+        Name of the symmetry group (Schönflies notation).
 
-def group_create(Nsites,group):
+    Returns
+    -------
+    tuple[list[list[int]], list[list[int]]]
+        The symmetry generators and the associated character table.
+
+    Raises
+    ------
+    ValueError
+        If the combination ``(Nsites, group)`` is not supported.
+    """
+
     if Nsites == 2 and group == "c2":
-        sym_gen = [[1,0]]
-        char_table = [[1,1],
-                     [1,-1]]
+        sym_gen = [[1, 0]]
+        char_table = [[1, 1], [1, -1]]
     elif Nsites == 3 and group == "c2":
-          sym_gen = [[1,0,2]]
-          char_table = [[1,1],
-                        [1,-1]]
+        sym_gen = [[1, 0, 2]]
+        char_table = [[1, 1], [1, -1]]
     elif Nsites == 3 and group == "d3":
-          sym_gen = [[1,0,2]]
-          char_table = [[1,1,1],
-                       [1,1,-1],
-                       [2,-1,0]]
-
+        sym_gen = [[1, 0, 2]]
+        char_table = [[1, 1, 1], [1, 1, -1], [2, -1, 0]]
     elif Nsites == 4 and group == "c2":
-        sym_gen = [[1,0,3,2]]
-        char_table = [[1,1],
-                        [1,-1]]
+        sym_gen = [[1, 0, 3, 2]]
+        char_table = [[1, 1], [1, -1]]
     elif Nsites == 4 and group == "c2v":
-        sym_gen = [[3,2,1,0],[1,0,3,2]]
-        char_table = [[1,1,1,1],
-                        [1,1,-1-1],
-                        [1,-1,1-1],
-                        [1,-1,-1,1]]
-    return sym_gen,char_table
+        sym_gen = [[3, 2, 1, 0], [1, 0, 3, 2]]
+        char_table = [
+            [1, 1, 1, 1],
+            [1, 1, -1, -1],
+            [1, -1, 1, -1],
+            [1, -1, -1, 1],
+        ]
+    else:  # unsupported combination
+        raise ValueError(f"Unsupported combination of Nsites={Nsites} and group='{group}'")
 
-
-
-
-
+    return sym_gen, char_table


### PR DESCRIPTION
## Summary
- fix malformed character table entries in `groups.group_create`
- raise an explicit `ValueError` for unsupported site/group combinations
- expand documentation on adding new symmetry groups and note future automated character table generation

## Testing
- `python -m py_compile groups.py && echo 'py_compile succeeded'`
- `python - <<'PY'
import groups
print(groups.group_create(4,"c2v"))
try:
    groups.group_create(5,"c2")
except ValueError as e:
    print("error", e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6892192c3b90832a912c743eefbae0a6