### PR TITLE
Call orbit_printer once in main

### DIFF
--- a/hubbard_diag_v5.py
+++ b/hubbard_diag_v5.py
@@ -69,24 +69,23 @@ def main():
 
  # print(hamiltonian())
 
-  print(orbit_printer())
+  orbits = orbit_printer()
+  print(orbits)
 
-
-
-  print(electron_number(orbit_printer()))
-  print("      ",total_spin(orbit_printer()))
-
+  print(electron_number(orbits))
+  print("      ", total_spin(orbits))
 
   print("matrices en bloc:")
-  for i in range(len(orbit_printer())):
-      print(block_matrix(orbit_printer()[i]))
-      print(np.linalg.eigh(block_matrix(orbit_printer()[i])))
-      
+  for orbit in orbits:
+      block = block_matrix(orbit)
+      print(block)
+      print(np.linalg.eigh(block))
 
   print("matrice symetriques:")
-  for i in range(len(orbit_printer())):
-      print(symmetric_block(orbit_printer()[i]))
-      print(np.linalg.eigh(symmetric_block(orbit_printer()[i])))
+  for orbit in orbits:
+      sblock = symmetric_block(orbit)
+      print(sblock)
+      print(np.linalg.eigh(sblock))
 
 def generator(list1):
     list2 = []


### PR DESCRIPTION
## Summary
- Cache `orbit_printer()` result in `main` and reuse it for subsequent computations

## Testing
- `python3 hubbard_diag_v5.py 2 "c2"` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python3 -m pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_689224c4210c832a9113d794c647bba0